### PR TITLE
feat: homeロゴの左右に最低25%の余白を確保

### DIFF
--- a/src/components/Home.astro
+++ b/src/components/Home.astro
@@ -25,6 +25,8 @@
     margin: auto;
     height: 50%;
     width: auto;
+    /* 左右にそれぞれ最低25%の余白を確保（画像は中央50%以内に収める） */
+    max-width: 50%;
     object-fit: contain;
   }
 


### PR DESCRIPTION
## 概要

Home セクションのロゴ画像に、左右それぞれ**最低25%**の余白を常に確保するようにしました。

## 変更内容

- `src/components/Home.astro` の `.large-logo` に `max-width: 50%` を追加
  - 画像を中央50%以内に収めることで、左右に25%ずつ以上の余白を確保
  - ロゴの縦横比によって幅が50%未満になる場合は、そのまま余白が広がる（＝「最低25%」の挙動）
  - `object-fit: contain` と中央寄せにより、幅上限に達しても縦横比を崩さず中央表示

## 確認

- `pnpm run build` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWY1ETBFyyZjufxd6vvi1K