### PR TITLE
feat: 推しスクロールをホイール/タッチ操作対応（自動送り＋手動）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ src/
     skills.ts         ← Skill[]（カテゴリ付き、表示順は Infra・OS / Database / Embedded / Dev Tools / App・Backend / Web / Creative。ユーザがインフラエンジニアのためインフラ系を先頭に配置）。img は原則 Skillicon。Skillicon に無いスキルのみ public/img/skill に画像を置いてローカル参照（Tailscale は正式ロゴ未用意のため network.jpg を仮画像に流用中、要差し替え）
     works.ts          ← Work[]（url / img / description）
     hobby.ts          ← HobbyItem[]（title / description?）。description は任意（なければ非表示）。画像・アイコンは持たない（画像は推し欄だけ）。現状: ダーツ・自宅サーバ運用・音楽鑑賞（音楽鑑賞は X @Hyouhyan の bio を参照して追加）
-    oshi.ts           ← OshiItem[]（name / description? / category? / img? / url?）。description は任意（なければ非表示）。Hobby.astro の h2「推し」サブセクションで小さめカードを**連続オートスクロール（CSSマーキー、ホバーで停止・スクロールバーなし・端フェード）**表示。**img 未指定＆url 指定なら、ビルド時に url の og:image を取得して img に補完**（下記 lib/og.ts）。img も url も無ければハートアイコン。url があればカード全体がリンク化。中身はユーザが後で記入
+    oshi.ts           ← OshiItem[]（name / description? / category? / img? / url?）。description は任意（なければ非表示）。Hobby.astro の h2「推し」サブセクションで小さめカードを**自動送り＋ホイール/タッチで手動左右スクロール**（Hobby.astro 内バニラJS。操作/ホバー中は自動停止、スクロールバー非表示、端フェード、シームレスループのためカードをJSで複製、prefers-reduced-motion で自動送りOFF）で表示。**img 未指定＆url 指定なら、ビルド時に url の og:image を取得して img に補完**（下記 lib/og.ts）。img も url も無ければハートアイコン。url があればカード全体がリンク化。中身はユーザが後で記入
     links.ts          ← LinkItem[]（url / label）
   lib/
     og.ts             ← ビルド時ユーティリティ。fetchOgImage(url)=ページの og:image（無ければ twitter:image）取得、resolveOshi(items)=推しの img 未指定分を og:image で補完。取得失敗時は undefined 返しでビルドは壊さない＋dev 用にモジュールキャッシュあり
@@ -60,7 +60,7 @@ public/               ← 静的ファイル。削除要注意（旧サイト・
 3. **Career** `#career` … タイムライン。**中身はプレースホルダー（Lorem ipsum / 準備中）**
 4. **Skill** `#skill` … スキル一覧（カテゴリ7分類、計60アイテム。GitHub プロフィール README のスキル一覧と同期済み）
 5. **Work** `#work` … 制作物カード（3件）
-6. **Hobby** `#hobby` … 趣味（テキスト主体のコンパクトカード、画像なし）＋ h2「推し」サブセクション（小さめカードを連続オートスクロール／CSSマーキー、画像あり）。**中身はユーザ記入済み（趣味: ダーツ・自宅サーバ運用／推し: VTuber 複数）**
+6. **Hobby** `#hobby` … 趣味（テキスト主体のコンパクトカード、画像なし）＋ h2「推し」サブセクション（小さめカードを自動送り＋ホイール/タッチで手動スクロール、画像あり）。**中身はユーザ記入済み（趣味: ダーツ・自宅サーバ運用ほか／推し: VTuber 複数）**
 7. **Link** `#link` … 外部リンクボタン（4件）
 
 - セクションを追加/並べ替えしたら、`Header.astro` のナビ `<li>` と `<script>` 内 `sectionIds` 配列、`global.css` の scroll-margin セレクタ（PC・モバイル2箇所）も合わせて更新すること。

--- a/src/components/Hobby.astro
+++ b/src/components/Hobby.astro
@@ -5,8 +5,6 @@ import { resolveOshi } from '../lib/og';
 
 // url があり img が空の推しは、ビルド時に og:image を取得して img を補完する
 const oshiItems = await resolveOshi(oshi);
-// マーキー1周の秒数。カード数に比例させてスクロール速度を一定に（最低18秒）
-const marqueeDuration = Math.max(oshiItems.length * 6, 18);
 ---
 
 <div class="hobby-box section" id="hobby">
@@ -24,14 +22,12 @@ const marqueeDuration = Math.max(oshiItems.length * 6, 18);
 
     <h2 class="subsection-title">推し</h2>
     <div class="oshi-marquee">
-      <div class="oshi-track" style={`animation-duration: ${marqueeDuration}s`}>
-        {[...oshiItems, ...oshiItems].map((o, i) => {
-          const dup = i >= oshiItems.length; // 後半はシームレスループ用の複製
+      <div class="oshi-track">
+        {oshiItems.map((o) => {
           const Tag = o.url ? 'a' : 'div';
           const props = {
-            class: `oshi-card${dup ? ' is-dup' : ''}`,
+            class: 'oshi-card',
             ...(o.url ? { href: o.url, target: '_blank', rel: 'noopener noreferrer' } : {}),
-            ...(dup ? { 'aria-hidden': 'true', tabindex: -1 } : {}),
           };
           return (
             <Tag {...props}>
@@ -93,37 +89,35 @@ const marqueeDuration = Math.max(oshiItems.length * 6, 18);
     line-height: 1.3;
   }
 
-  /* ===== 推し（小さめカードを連続オートスクロール＝マーキー） ===== */
+  /* ===== 推し（自動送り＋ホイール/タッチで手動操作できる横スクロール） ===== */
   .oshi-marquee {
-    overflow: hidden;
+    overflow-x: auto;
+    overflow-y: hidden;
     /* ホバー時の浮き＆影がクリップされないための縦余白 */
     padding: 8px 0 22px;
     /* 左右端をふわっとフェード */
     -webkit-mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
     mask-image: linear-gradient(to right, transparent, #000 24px, #000 calc(100% - 24px), transparent);
+    /* スマホの慣性スクロール。横スクロールでブラウザの戻る等を誘発しない */
+    -webkit-overflow-scrolling: touch;
+    overscroll-behavior-x: contain;
+    /* スクロールバーは非表示 */
+    scrollbar-width: none;
+  }
+
+  .oshi-marquee::-webkit-scrollbar {
+    display: none;
   }
 
   .oshi-track {
     display: flex;
     width: max-content;
-    /* animation-duration はインラインで指定（カード数比例） */
-    animation: oshi-scroll 36s linear infinite;
-  }
-
-  /* ホバー中は停止（カードを読む/クリックしやすく） */
-  .oshi-marquee:hover .oshi-track {
-    animation-play-state: paused;
-  }
-
-  @keyframes oshi-scroll {
-    from { transform: translateX(0); }
-    to   { transform: translateX(-50%); }
   }
 
   .oshi-card {
     flex: 0 0 auto;
     width: 140px;
-    margin-right: 14px;   /* gap 相当。カード側に持たせて -50% ループを正確にする */
+    margin-right: 14px;   /* カード間隔（JS 複製時もこの間隔でループする） */
     border: 1px solid var(--color-border-light);
     border-radius: 10px;
     overflow: hidden;
@@ -187,24 +181,97 @@ const marqueeDuration = Math.max(oshiItems.length * 6, 18);
     line-height: 1.6;
     margin: 0;
   }
-
-  /* 動きを減らす設定: オートスクロールを止め、複製を隠して折り返し表示 */
-  @media (prefers-reduced-motion: reduce) {
-    .oshi-track {
-      animation: none;
-      flex-wrap: wrap;
-      width: 100%;
-      row-gap: 14px;
-    }
-
-    .oshi-card.is-dup {
-      display: none;
-    }
-
-    .oshi-marquee {
-      padding-bottom: 8px;
-      -webkit-mask-image: none;
-      mask-image: none;
-    }
-  }
 </style>
+
+<script>
+  // 推し: 横スクロールコンテナを rAF で自動送りしつつ、ホイール/タッチで手動操作できるようにする。
+  // シームレスにループさせるため、1セット分のカードを JS で必要数だけ複製する。
+  document.querySelectorAll<HTMLElement>('.oshi-marquee').forEach((marquee) => {
+    const track = marquee.querySelector<HTMLElement>('.oshi-track');
+    if (!track || track.children.length === 0) return;
+
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const SPEED = 0.4; // 1フレームあたりの送り量(px)
+
+    // 元の1セットを複製用に保持
+    const originals = Array.from(track.children);
+    const setCount = originals.length;
+
+    const appendClones = () => {
+      for (const el of originals) {
+        const clone = el.cloneNode(true) as HTMLElement;
+        clone.setAttribute('aria-hidden', 'true');
+        clone.setAttribute('tabindex', '-1');
+        track.appendChild(clone);
+      }
+    };
+
+    // まず1セット複製し、正確な1セット幅（ストライド）を測る
+    appendClones();
+    const oneSetWidth =
+      (track.children[setCount] as HTMLElement).offsetLeft -
+      (track.children[0] as HTMLElement).offsetLeft;
+    if (oneSetWidth <= 0) return;
+
+    // 画面幅 + 2セット分を超えるまで複製（両方向に余白を確保）
+    let guard = 0;
+    while (track.scrollWidth < marquee.clientWidth + oneSetWidth * 2 && guard < 30) {
+      appendClones();
+      guard++;
+    }
+
+    // scrollLeft を [oneSetWidth, 2*oneSetWidth) に保つ。複製は同一内容なのでジャンプは不可視
+    const normalize = () => {
+      if (marquee.scrollLeft >= oneSetWidth * 2) marquee.scrollLeft -= oneSetWidth;
+      else if (marquee.scrollLeft < oneSetWidth) marquee.scrollLeft += oneSetWidth;
+    };
+    marquee.scrollLeft = oneSetWidth;
+
+    let autoplay = !reduce; // 動きを減らす設定では自動送りしない
+    let resumeTimer: number | undefined;
+    let acc = 0; // 端数をためて 1px 単位で送る（scrollLeft の丸め対策）
+
+    const holdAuto = (ms: number) => {
+      autoplay = false;
+      if (resumeTimer) clearTimeout(resumeTimer);
+      resumeTimer = window.setTimeout(() => { autoplay = !reduce; }, ms);
+    };
+
+    const tick = () => {
+      if (autoplay) {
+        acc += SPEED;
+        const step = Math.trunc(acc);
+        if (step) {
+          acc -= step;
+          marquee.scrollLeft += step;
+          normalize();
+        }
+      }
+      requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+
+    // ホバー中は停止（読む/クリックしやすく）
+    marquee.addEventListener('mouseenter', () => { autoplay = false; });
+    marquee.addEventListener('mouseleave', () => {
+      if (resumeTimer) clearTimeout(resumeTimer);
+      autoplay = !reduce;
+    });
+
+    // ホイール: 縦横どちらの回転でも横スクロールに変換
+    marquee.addEventListener('wheel', (e) => {
+      const delta = Math.abs(e.deltaX) >= Math.abs(e.deltaY) ? e.deltaX : e.deltaY;
+      if (!delta) return;
+      e.preventDefault();
+      marquee.scrollLeft += delta;
+      normalize();
+    }, { passive: false });
+
+    // タッチ: ネイティブの横スクロールに任せ、自動送りだけ止める
+    marquee.addEventListener('touchstart', () => holdAuto(60000), { passive: true });
+    marquee.addEventListener('touchend', () => holdAuto(1500), { passive: true });
+
+    // 手動スクロールでもループ位置を維持
+    marquee.addEventListener('scroll', normalize, { passive: true });
+  });
+</script>


### PR DESCRIPTION
## 概要

推し（HOBBY セクション内 h2「推し」）のカード列を、CSSアニメーションのマーキーから **スクロールコンテナ＋バニラJSの自動送り** に作り替え、**マウスホイール・タッチで左右に手動操作**できるようにしました。

## 挙動

- **マウスホイール**: 縦回転・横回転どちらも横スクロールに変換
- **タッチ**: 指で左右スワイプ（ネイティブの慣性スクロール）
- **自動送り**: 無操作時はゆっくり自動で流れる
- **操作/ホバー中は自動停止**: ホバー中や操作直後は止まり、離れる／指を離して少し経つと再開
- **無限ループ**: カードを実行時に必要数だけ複製し、`scrollLeft` を1セット幅の範囲に正規化してシームレスに周回（左右どちらも詰まらない）
- スクロールバー非表示・端フェードは維持
- `prefers-reduced-motion` では自動送りOFF（手動操作は可）
- `overscroll-behavior-x: contain` で横スクロールがブラウザの「戻る」等を誘発しないように

## 実装メモ

- サーバ側は推し1セットのみ描画。複製・自動送り・ホイール変換は `Hobby.astro` 内のクライアントスクリプト（バニラJS）。JSなしでもカードは表示され、タッチ/トラックパッドでの横スクロールは効く
- スクロールの中核ロジック（複製数・ループ境界・自動送りの連続性・ホイール操作）を数値シミュレーションで検証済み（継ぎ目のジャンプ0、件数1〜12でも複製が足りる）

## トレードオフ

推しの上にカーソルがある間は、縦ホイールが横スクロールに変換される仕様上、そこではページの縦スクロールが止まります（帯の高さは約200pxなので通過は一瞬）。「ホイールで左右操作」を優先した結果です。

## 確認

- `pnpm run build` が通ることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWY1ETBFyyZjufxd6vvi1K