### PR TITLE
docs: CLAUDE.md/README.md を実装に合わせて同期

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,9 @@ src/
   styles/
     global.css        ← CSS変数・リセット・フォント・共通スタイル（ここが唯一の設定起点）
   layouts/
-    Base.astro        ← <head>・Font Awesome
+    Base.astro        ← <head>・OGP メタ・Font Awesome
   components/
-    Header.astro      ← 固定左縦型ナビ＋右SNSパネル（スクロール連動）。スコープCSS＋バニラJS内蔵
+    Header.astro      ← 固定左縦型ナビ（スクロール連動）。スコープCSS＋バニラJS内蔵
     Home.astro        ← フルスクリーンヒーロー（ロゴ画像＋スクロールダウン矢印）
     About.astro       ← 2カラム（丸アイコン＋名前・本文・SNSリンク）
     Career.astro      ← タイムライン。データは src/data/career.ts
@@ -37,11 +37,11 @@ src/
     Links.astro       ← 黒枠ホバー反転ボタン。データは src/data/links.ts
     Footer.astro      ← フッター（著作権表示）
   data/
-    career.ts         ← CareerItem[] プレースホルダー。中身はユーザが後で記入
-    skills.ts         ← Skill[]（カテゴリ付き、表示順は Infra・OS / Database / Embedded / Dev Tools / App・Backend / Web / Creative。ユーザがインフラエンジニアのためインフラ系を先頭に配置）。img は原則 Skillicon。Skillicon に無いスキルのみ public/img/skill に画像を置いてローカル参照（Tailscale は正式ロゴ未用意のため network.jpg を仮画像に流用中、要差し替え）
+    career.ts         ← CareerItem[]。実データ記入済み（2022/4 大学入学 〜 2028/3 大学院修士課程 修了予定。研究室配属・JOJIハウス等）
+    skills.ts         ← Skill[]（計63件）。表示順 skillCategories = Infra / OS → Languages → Database → Embedded → Dev Tools → Creative（インフラエンジニアなのでインフラ系を先頭）。一部カテゴリは subcategory（h3見出し）でさらに細分（Frameworks / Tools・Web / Frontend・Web / Backend）。img は原則 skillicon()（skillicons.dev）、無いものは simpleIcon()（cdn.simpleicons.org）か public/img/skill のローカル画像（Tailscale は正式ロゴ未用意で network.jpg を仮画像に流用中、要差し替え）
     works.ts          ← Work[]（url / img / description）
-    hobby.ts          ← HobbyItem[]（title / description?）。description は任意（なければ非表示）。画像・アイコンは持たない（画像は推し欄だけ）。現状: ダーツ・自宅サーバ運用・音楽鑑賞（音楽鑑賞は X @Hyouhyan の bio を参照して追加）
-    oshi.ts           ← OshiItem[]（name / description? / category? / img? / url?）。description は任意（なければ非表示）。Hobby.astro の h2「推し」サブセクションで小さめカードを**自動送り＋ホイール/タッチで手動左右スクロール**（Hobby.astro 内バニラJS。操作/ホバー中は自動停止、スクロールバー非表示、端フェード、シームレスループのためカードをJSで複製、prefers-reduced-motion で自動送りOFF）で表示。**img 未指定＆url 指定なら、ビルド時に url の og:image を取得して img に補完**（下記 lib/og.ts）。img も url も無ければハートアイコン。url があればカード全体がリンク化。中身はユーザが後で記入
+    hobby.ts          ← HobbyItem[]（title / description?）。description は任意（なければ非表示）。画像・アイコンは持たない（画像は推し欄だけ）。現状: ダーツ・自宅サーバ運用・遠征・カラオケ・日本酒
+    oshi.ts           ← OshiItem[]（name / description? / category? / img? / url?）。description は任意（なければ非表示）。Hobby.astro の h2「推し」サブセクションで小さめカードを**自動送り＋ホイール/タッチで手動左右スクロール**（Hobby.astro 内バニラJS。操作/ホバー中は自動停止、スクロールバー非表示、端フェード、シームレスループのためカードをJSで複製、prefers-reduced-motion で自動送りOFF）で表示。**img 未指定＆url 指定なら、ビルド時に url の og:image を取得して img に補完**（下記 lib/og.ts）。img も url も無ければハートアイコン。url があればカード全体がリンク化。現状: VTuber 7組（ヒメヒナ・花譜・明透・KMNZ・V.W.P・ミライアカリ・大蔦エル。いずれも url→og:image で画像解決）
     links.ts          ← LinkItem[]（url / label）
   lib/
     og.ts             ← ビルド時ユーティリティ。fetchOgImage(url)=ページの og:image（無ければ twitter:image）取得、resolveOshi(items)=推しの img 未指定分を og:image で補完。取得失敗時は undefined 返しでビルドは壊さない＋dev 用にモジュールキャッシュあり
@@ -56,11 +56,11 @@ public/               ← 静的ファイル。削除要注意（旧サイト・
 ## 現在のページ構成（セクション順）
 
 1. **Home** `#home` … フルスクリーンヒーロー（ロゴ画像）
-2. **About** `#about` … 自己紹介。プレースホルダーテキスト入り
-3. **Career** `#career` … タイムライン。**中身はプレースホルダー（Lorem ipsum / 準備中）**
-4. **Skill** `#skill` … スキル一覧（カテゴリ7分類、計60アイテム。GitHub プロフィール README のスキル一覧と同期済み）
+2. **About** `#about` … 自己紹介（記入済み。丸アイコン＋本文＋SNSリンク）
+3. **Career** `#career` … タイムライン（記入済み。2022〜2028）
+4. **Skill** `#skill` … スキル一覧（6カテゴリ・計63アイテム。GitHub プロフィール README のスキル一覧と同期）
 5. **Work** `#work` … 制作物カード（3件）
-6. **Hobby** `#hobby` … 趣味（テキスト主体のコンパクトカード、画像なし）＋ h2「推し」サブセクション（小さめカードを自動送り＋ホイール/タッチで手動スクロール、画像あり）。**中身はユーザ記入済み（趣味: ダーツ・自宅サーバ運用ほか／推し: VTuber 複数）**
+6. **Hobby** `#hobby` … 趣味（テキスト主体のコンパクトカード、画像なし・5件）＋ h2「推し」サブセクション（小さめカードを自動送り＋ホイール/タッチで手動スクロール、画像あり・VTuber 7組）
 7. **Link** `#link` … 外部リンクボタン（4件）
 
 - セクションを追加/並べ替えしたら、`Header.astro` のナビ `<li>` と `<script>` 内 `sectionIds` 配列、`global.css` の scroll-margin セレクタ（PC・モバイル2箇所）も合わせて更新すること。
@@ -96,7 +96,7 @@ public/               ← 静的ファイル。削除要注意（旧サイト・
 
 ## やりたいこと（任意・順次）
 
-- **Career セクションの中身を記入**（`src/data/career.ts` にユーザが実績を入力）
-- **About セクションの拡充**（文章・写真の追加）
 - Now（研究）セクションの追加を検討
 - ブログを足すなら Astro の Content Collections（Markdown 管理）を検討
+- OGP に `og:image` 等を追加（現状 `Base.astro` は og:image 未設定で、Discord 等シェア時にサムネが出ない。`twitter:card` の `summary_large_image` 化も）
+- 推しの画像は url→og:image のホットリンク依存。活動終了先で将来取得に失敗しうる（フォールバック改善やガイドライン許容素材のローカル化は検討保留中）

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ pnpm run preview  # ビルド結果をローカル確認
 3. **Career** … タイムライン
 4. **Skill** … カテゴリ別のスキルグリッド
 5. **Work** … ホバーで説明が出る制作物カード
-6. **Link** … 外部リンクボタン
+6. **Hobby** … 趣味カード＋「推し」サブセクション（自動送り＋ホイール/タッチで操作できる横スクロール。画像は URL の og:image をビルド時取得）
+7. **Link** … 外部リンクボタン
 
 このほかに、エラーページ（`401` / `404` / `418`）を Astro で用意しています。
 
@@ -39,9 +40,13 @@ src/
 │  ├─ career.ts
 │  ├─ skills.ts
 │  ├─ works.ts
+│  ├─ hobby.ts
+│  ├─ oshi.ts
 │  └─ links.ts
 ├─ components/        # 各セクションの部品（Header / Home / About / Career /
-│  │                  #   Skills / Works / Links / Footer / ErrorPage）
+│  │                  #   Skills / Works / Hobby / Links / Footer / ErrorPage）
+├─ lib/
+│  └─ og.ts           #   ビルド時に URL の og:image を取得（推しの画像補完に使用）
 ├─ layouts/
 │  └─ Base.astro      #   <head>・OGP・Font Awesome
 ├─ styles/
@@ -63,6 +68,7 @@ src/
 - スクリプト: バニラ JS（Astro の `<script>` タグ）。jQuery は廃止済み
 - フォント: Noto Sans JP（Google Fonts）。ロゴは画像なので、以前使っていた Adobe Typekit は削除済み
 - アイコン: Font Awesome（SNS）、Skillicon（スキル）
+- 推しの画像は `src/lib/og.ts` が**ビルド時**に対象 URL の og:image を取得して埋め込む（実行時 API は無し。取得失敗時はハート表示にフォールバック）
 
 ## 触るときの注意
 


### PR DESCRIPTION
## 概要

実装との乖離が出ていた `CLAUDE.md` と `README.md` を、現状のコードに合わせて更新しました。ドキュメントのみの変更で、挙動・出力への影響はありません。

## CLAUDE.md
- **Career**: 「プレースホルダー」→ 実データ記入済み（2022/4 大学入学 〜 2028/3 大学院修士課程 修了予定）
- **About**: 「プレースホルダーテキスト」→ 記入済み
- **Skill**: 「7分類・60件」＆旧カテゴリ順 → **6カテゴリ・63件**、正しい表示順（Infra / OS → Languages → Database → Embedded → Dev Tools → Creative）＋ subcategory（Frameworks / Tools・Web / Frontend・Web / Backend）。`simpleIcon()` 併用も追記
- **hobby**: 実態の ダーツ・自宅サーバ運用・遠征・カラオケ・日本酒 に修正
- **推し**: 「後で記入」→ VTuber 7組（記入済み）
- **Header**: 実装に存在しない「右SNSパネル」の記述を削除
- **Base.astro**: OGP メタを持つ旨を追記
- **やりたいこと**: 完了済み項目（Career記入・About拡充）を削除、OGP `og:image` 追加・推し画像の耐久性を今後の項目として追記

## README.md
- ページ構成に **Hobby** を追加（Link を7番目に）
- ディレクトリに `hobby.ts` / `oshi.ts` / `lib/og.ts`、components に Hobby を追記
- 技術スタックに「推し画像はビルド時に og:image を取得（実行時 API は無し）」を追記

## 確認
- `pnpm run build` が通ることを確認済み（ドキュメントのみのため出力に変化なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TWY1ETBFyyZjufxd6vvi1K